### PR TITLE
Add browser-based Twitch Wavelength helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,82 @@
-# Wavelength Live pour Twitch
+# Wavelength Live pour Twitch (aucun code requis)
 
-Cette mini-application 100% gratuite vous permet de jouer à une version "chat" du jeu Wavelength directement sur votre stream Twitch. Elle fonctionne dans n'importe quel navigateur moderne sans installation logicielle : il suffit d'ouvrir `index.html` en local (dans OBS vous pouvez ajouter la page comme "Browser Source").
+Cette page web vous permet de recréer gratuitement le jeu **Wavelength** avec votre chat Twitch. Tout se passe dans votre navigateur : pas besoin de connaître le code, GitHub ou d’installer un programme. Vous allez simplement télécharger un fichier et l’ouvrir.
 
-## Fonctionnalités principales
+## Ce dont vous avez besoin
 
-- Connexion directe au chat Twitch via [`tmi.js`](https://tmijs.com/).
-- Génération aléatoire d'une valeur secrète (0 à 100) cachée par défaut pour ne pas spoiler les viewers.
-- Champ personnalisable pour les deux extrêmes de la manche.
-- Lecture en temps réel des commandes `!nombre` envoyées par le chat.
-- Calcul automatique de la moyenne des votes uniques du chat et suivi du dernier vote reçu.
-- Bouton de révélation qui affiche la moyenne finale, la cible et l'écart.
+- Un ordinateur (Windows ou Mac) utilisé pour streamer.
+- Une connexion internet pour accéder au chat Twitch.
+- Un navigateur moderne déjà installé (Chrome, Edge, Firefox, etc.).
+- (Facultatif) OBS ou un logiciel de streaming si vous voulez afficher le jeu à l’écran.
+- Votre chaîne Twitch et, si vous le souhaitez, un compte bot secondaire.
 
-## Mise en route (moins de 10 minutes)
+## Étape 1 – Télécharger le fichier du jeu
 
-1. **Téléchargez le dépôt** ou copiez simplement le fichier `index.html` sur votre ordinateur de streaming.
-2. **Ouvrez le fichier** dans votre navigateur (clic droit → ouvrir avec Chrome/Edge/Firefox). Pour l'afficher sur OBS, ajoutez-le comme *Browser Source* en pointant vers `file:///…/index.html`.
-3. **Configurez la connexion au chat** :
-   - *Chaîne Twitch* : le nom de votre chaîne sans le `#` (obligatoire).
-   - *Pseudo Twitch du bot* : laissez vide si vous ne faites que lire le chat. Remplissez-le si vous disposez d’un compte bot dédié.
-   - *Jeton OAuth* : laissez vide pour une connexion anonyme (lecture seule). Si vous renseignez un pseudo bot, ajoutez également son jeton OAuth.
-4. Cliquez sur **Connexion**. Le statut passera en vert (`Connecté au chat`) une fois la connexion établie.
+1. Ouvrez la page GitHub du projet (l’adresse où vous lisez ce guide) et cliquez sur le bouton vert **Code** en haut à droite de la liste des fichiers.
+2. Choisissez **Download ZIP** (Télécharger ZIP). Un fichier compressé va se télécharger sur votre ordinateur.
+3. Ouvrez le fichier ZIP (double-cliquez dessus). Si une fenêtre vous propose *Extraire tout*, acceptez, puis faites glisser le fichier **`index.html`** vers un dossier facile à retrouver (par exemple le Bureau).
 
-> 💡 Pour plus de sécurité, créez un compte Twitch secondaire dédié au bot si vous souhaitez envoyer des messages automatisés.
+> 💡 Vous n’avez besoin que de ce fichier `index.html`. Une fois qu’il est sur votre ordinateur, vous pouvez fermer l’onglet GitHub : tout se lance localement dans votre navigateur.
 
-### Générer un jeton OAuth (optionnel)
+## Étape 2 – Ouvrir le jeu
 
-L’application peut lire le chat Twitch en mode anonyme, ce qui suffit pour la majorité des usages. Vous n’avez donc pas besoin de token tant que vous n’envoyez pas de messages via le bot.
+1. Localisez le fichier `index.html` sur votre ordinateur.
+2. Double-cliquez dessus : il s’ouvrira automatiquement dans votre navigateur.
+3. Vous voyez maintenant l’interface du jeu prête à être configurée.
 
-Si vous voulez tout de même authentifier un compte bot, deux possibilités :
+### L’intégrer à OBS (facultatif)
 
-1. **Méthode officielle Twitch** (recommandée par la documentation) :
-   - Créez une application sur <https://dev.twitch.tv/console/apps> et notez le `Client ID` et le `Client Secret`.
-   - Ajoutez `http://localhost` dans la liste des *Redirect URIs*.
-   - Suivez le guide <https://dev.twitch.tv/docs/irc/authenticate-bot/> pour obtenir un token `chat:read chat:edit` et copiez la valeur qui commence par `oauth:`.
-2. **Générateur communautaire maintenu** : <https://twitchtokengenerator.com/quick/tmi> propose une interface simplifiée pour générer un token `chat:read`/`chat:edit`. Connectez-vous avec le compte bot, copiez le token (préfixe `oauth:`) et collez-le dans le champ prévu.
+1. Ouvrez OBS.
+2. Dans la scène de votre choix, cliquez sur le bouton **+** de la liste *Sources*.
+3. Choisissez **Source navigateur** (Browser Source).
+4. Dans le champ *URL*, tapez `file:///` puis collez le chemin complet vers `index.html`. Le plus simple : cliquez sur **Parcourir** (Browse) et sélectionnez le fichier.
+5. Validez : l’interface du jeu s’affiche dans OBS.
 
-> ℹ️ Quel que soit le procédé utilisé, traitez votre token comme un mot de passe : ne le partagez pas et régénérez-le en cas de doute.
+## Étape 3 – Connecter le chat Twitch
 
-## Jouer une manche
+Dans la partie gauche de l’interface :
 
-1. Saisissez les deux extrêmes (0 = gauche, 100 = droite).
-2. Cliquez sur **Générer une valeur** : la cible aléatoire apparaît dans le cartouche secret.
-3. Masquez la valeur (`Afficher / Masquer`) avant de remettre la scène sur votre stream.
-4. Lancez le chrono oralement et demandez au chat d'envoyer `!0` à `!100`.
-5. Observez la moyenne en direct, le nombre de votants et le dernier vote.
-6. Quand le temps est écoulé, cliquez sur **Révéler la cible & l'écart** pour afficher le résultat final.
-7. Cliquez sur **Réinitialiser les votes** pour préparer le tour suivant.
+1. **Chaîne Twitch** : écrivez simplement le nom de votre chaîne (sans `#`). Exemple : `monstream`.
+2. **Pseudo Twitch du bot** :
+   - Laissez ce champ vide si vous ne faites que lire les messages du chat (c’est le cas le plus simple).
+   - Remplissez-le avec un compte bot si vous voulez que le jeu envoie des messages automatiques.
+3. **Jeton OAuth** :
+   - Laissez vide si vous êtes en mode lecture seule (connexion anonyme autorisée par Twitch).
+   - Remplissez-le uniquement si vous avez indiqué un compte bot et disposez de son jeton.
+4. Cliquez sur **Connexion**. Le voyant passe au vert avec le texte `Connecté au chat`.
 
-## Bonnes pratiques
+> ❗ Si le voyant reste rouge : vérifiez l’orthographe de votre chaîne ou relancez votre navigateur.
 
-- Seul le dernier vote d'un viewer est conservé pour éviter le spam : le bot met automatiquement la moyenne à jour.
-- L'interface ne stocke rien sur un serveur : toutes les données restent dans votre navigateur.
-- Si la connexion au chat tombe, appuyez sur **Déconnexion** puis **Connexion**.
+## Étape 4 – Jouer une manche
 
-## Personnalisation
+1. Indiquez les deux extrêmes (ex. `0 = Froid`, `100 = Chaud`).
+2. Cliquez sur **Générer une valeur** : une valeur secrète apparaît dans le panneau bleu.
+3. Masquez la valeur (bouton **Afficher / Masquer**) avant de retourner sur la scène en direct.
+4. Expliquez au chat qu’il doit taper `!` suivi d’un nombre (exemple `!42`).
+5. Les votes apparaissent automatiquement : suivez la moyenne, le nombre de votants et le dernier message reçu.
+6. Quand vous le souhaitez, cliquez sur **Révéler la cible & l'écart** pour montrer la valeur exacte et la moyenne du chat.
+7. Cliquez sur **Réinitialiser les votes** pour passer au tour suivant.
 
-Le fichier est autonome : vous pouvez ajuster les couleurs ou les textes directement dans `index.html`. Pour toute modification, gardez la structure HTML/JS existante afin de ne pas casser la connexion au chat.
+## (Optionnel) Obtenir un jeton OAuth pour un bot
+
+Vous n’en avez pas besoin pour lire le chat. Si vous souhaitez qu’un compte bot envoie des messages, créez un compte Twitch secondaire et suivez l’une des méthodes suivantes :
+
+1. **Méthode officielle Twitch** (plus technique) : guide complet ici <https://dev.twitch.tv/docs/irc/authenticate-bot/>.
+2. **Générateur simple** : <https://twitchtokengenerator.com/quick/tmi> (sélectionnez les permissions `chat:read` et `chat:edit`).
+
+Dans les deux cas, copiez la chaîne de caractères qui commence par `oauth:` et collez-la dans le champ *Jeton OAuth*.
+
+> Gardez ce jeton secret : il donne accès au compte bot.
+
+## Résolution de problèmes courants
+
+- **Rien ne s’affiche dans OBS** : vérifiez que l’URL pointe bien vers le fichier `index.html` (avec `file:///`).
+- **Le statut reste déconnecté** : assurez-vous que votre chaîne Twitch est correctement orthographiée et que vous avez cliqué sur **Connexion**.
+- **Les votes ne bougent pas** : rappelez au chat de taper un `!` avant le nombre (`!50`, `!73`, etc.).
+- **Vous avez changé de scène et perdu la connexion** : cliquez sur **Déconnexion** puis **Connexion** pour relancer.
+
+## Personnaliser le visuel (facultatif)
+
+Si vous vous sentez à l’aise, vous pouvez ouvrir `index.html` avec un éditeur de texte (Bloc-notes, VS Code) pour changer les couleurs ou les textes. Ne modifiez pas le reste du fichier si vous n’êtes pas sûr de ce que vous faites.
 
 Bon stream et amusez-vous bien avec votre version Live de Wavelength !

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# Test-WL
+# Wavelength Live pour Twitch
+
+Cette mini-application 100% gratuite vous permet de jouer à une version "chat" du jeu Wavelength directement sur votre stream Twitch. Elle fonctionne dans n'importe quel navigateur moderne sans installation logicielle : il suffit d'ouvrir `index.html` en local (dans OBS vous pouvez ajouter la page comme "Browser Source").
+
+## Fonctionnalités principales
+
+- Connexion directe au chat Twitch via [`tmi.js`](https://tmijs.com/).
+- Génération aléatoire d'une valeur secrète (0 à 100) cachée par défaut pour ne pas spoiler les viewers.
+- Champ personnalisable pour les deux extrêmes de la manche.
+- Lecture en temps réel des commandes `!nombre` envoyées par le chat.
+- Calcul automatique de la moyenne des votes uniques du chat et suivi du dernier vote reçu.
+- Bouton de révélation qui affiche la moyenne finale, la cible et l'écart.
+
+## Mise en route (moins de 10 minutes)
+
+1. **Téléchargez le dépôt** ou copiez simplement le fichier `index.html` sur votre ordinateur de streaming.
+2. **Ouvrez le fichier** dans votre navigateur (clic droit → ouvrir avec Chrome/Edge/Firefox). Pour l'afficher sur OBS, ajoutez-le comme *Browser Source* en pointant vers `file:///…/index.html`.
+3. **Renseignez vos identifiants Twitch** :
+   - *Chaîne Twitch* : le nom de votre chaîne sans le `#`.
+   - *Pseudo Twitch du bot* : votre compte ou un compte bot secondaire.
+   - *Jeton OAuth* :
+     1. Visitez [https://twitchapps.com/tmi/](https://twitchapps.com/tmi/) (site officiel utilisé par la communauté).
+     2. Connectez-vous avec le compte qui enverra les messages.
+     3. Copiez la clé générée (elle commence par `oauth:`) et collez-la dans le champ « Jeton OAuth ».
+4. Cliquez sur **Connexion**. Le statut doit passer au vert (`Connecté au chat`).
+
+> 💡 Pour plus de sécurité, vous pouvez créer un compte Twitch secondaire dédié au bot.
+
+## Jouer une manche
+
+1. Saisissez les deux extrêmes (0 = gauche, 100 = droite).
+2. Cliquez sur **Générer une valeur** : la cible aléatoire apparaît dans le cartouche secret.
+3. Masquez la valeur (`Afficher / Masquer`) avant de remettre la scène sur votre stream.
+4. Lancez le chrono oralement et demandez au chat d'envoyer `!0` à `!100`.
+5. Observez la moyenne en direct, le nombre de votants et le dernier vote.
+6. Quand le temps est écoulé, cliquez sur **Révéler la cible & l'écart** pour afficher le résultat final.
+7. Cliquez sur **Réinitialiser les votes** pour préparer le tour suivant.
+
+## Bonnes pratiques
+
+- Seul le dernier vote d'un viewer est conservé pour éviter le spam : le bot met automatiquement la moyenne à jour.
+- L'interface ne stocke rien sur un serveur : toutes les données restent dans votre navigateur.
+- Si la connexion au chat tombe, appuyez sur **Déconnexion** puis **Connexion**.
+
+## Personnalisation
+
+Le fichier est autonome : vous pouvez ajuster les couleurs ou les textes directement dans `index.html`. Pour toute modification, gardez la structure HTML/JS existante afin de ne pas casser la connexion au chat.
+
+Bon stream et amusez-vous bien avec votre version Live de Wavelength !

--- a/README.md
+++ b/README.md
@@ -15,16 +15,27 @@ Cette mini-application 100% gratuite vous permet de jouer à une version "chat" 
 
 1. **Téléchargez le dépôt** ou copiez simplement le fichier `index.html` sur votre ordinateur de streaming.
 2. **Ouvrez le fichier** dans votre navigateur (clic droit → ouvrir avec Chrome/Edge/Firefox). Pour l'afficher sur OBS, ajoutez-le comme *Browser Source* en pointant vers `file:///…/index.html`.
-3. **Renseignez vos identifiants Twitch** :
-   - *Chaîne Twitch* : le nom de votre chaîne sans le `#`.
-   - *Pseudo Twitch du bot* : votre compte ou un compte bot secondaire.
-   - *Jeton OAuth* :
-     1. Visitez [https://twitchapps.com/tmi/](https://twitchapps.com/tmi/) (site officiel utilisé par la communauté).
-     2. Connectez-vous avec le compte qui enverra les messages.
-     3. Copiez la clé générée (elle commence par `oauth:`) et collez-la dans le champ « Jeton OAuth ».
-4. Cliquez sur **Connexion**. Le statut doit passer au vert (`Connecté au chat`).
+3. **Configurez la connexion au chat** :
+   - *Chaîne Twitch* : le nom de votre chaîne sans le `#` (obligatoire).
+   - *Pseudo Twitch du bot* : laissez vide si vous ne faites que lire le chat. Remplissez-le si vous disposez d’un compte bot dédié.
+   - *Jeton OAuth* : laissez vide pour une connexion anonyme (lecture seule). Si vous renseignez un pseudo bot, ajoutez également son jeton OAuth.
+4. Cliquez sur **Connexion**. Le statut passera en vert (`Connecté au chat`) une fois la connexion établie.
 
-> 💡 Pour plus de sécurité, vous pouvez créer un compte Twitch secondaire dédié au bot.
+> 💡 Pour plus de sécurité, créez un compte Twitch secondaire dédié au bot si vous souhaitez envoyer des messages automatisés.
+
+### Générer un jeton OAuth (optionnel)
+
+L’application peut lire le chat Twitch en mode anonyme, ce qui suffit pour la majorité des usages. Vous n’avez donc pas besoin de token tant que vous n’envoyez pas de messages via le bot.
+
+Si vous voulez tout de même authentifier un compte bot, deux possibilités :
+
+1. **Méthode officielle Twitch** (recommandée par la documentation) :
+   - Créez une application sur <https://dev.twitch.tv/console/apps> et notez le `Client ID` et le `Client Secret`.
+   - Ajoutez `http://localhost` dans la liste des *Redirect URIs*.
+   - Suivez le guide <https://dev.twitch.tv/docs/irc/authenticate-bot/> pour obtenir un token `chat:read chat:edit` et copiez la valeur qui commence par `oauth:`.
+2. **Générateur communautaire maintenu** : <https://twitchtokengenerator.com/quick/tmi> propose une interface simplifiée pour générer un token `chat:read`/`chat:edit`. Connectez-vous avec le compte bot, copiez le token (préfixe `oauth:`) et collez-le dans le champ prévu.
+
+> ℹ️ Quel que soit le procédé utilisé, traitez votre token comme un mot de passe : ne le partagez pas et régénérez-le en cas de doute.
 
 ## Jouer une manche
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,563 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Wavelength Live Twitch</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family: "Rubik", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: radial-gradient(circle at top, #1f2933, #111827 55%);
+      color: #e5e7eb;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+      padding: 24px;
+      box-sizing: border-box;
+    }
+
+    main {
+      width: min(960px, 100%);
+      background: rgba(15, 23, 42, 0.8);
+      backdrop-filter: blur(12px);
+      border-radius: 18px;
+      padding: 32px;
+      box-shadow: 0 24px 60px rgba(15, 23, 42, 0.6);
+      display: flex;
+      flex-direction: column;
+      gap: 32px;
+    }
+
+    h1 {
+      font-size: clamp(2rem, 4vw, 2.8rem);
+      margin: 0;
+      text-align: center;
+      color: #facc15;
+      letter-spacing: 0.04em;
+    }
+
+    section {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      background: rgba(30, 41, 59, 0.75);
+      padding: 24px;
+      border-radius: 16px;
+      border: 1px solid rgba(148, 163, 184, 0.12);
+    }
+
+    section header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+    }
+
+    section header h2 {
+      margin: 0;
+      font-size: 1.2rem;
+      letter-spacing: 0.02em;
+      color: #bfdbfe;
+    }
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 0.95rem;
+    }
+
+    input, button, select {
+      font: inherit;
+      border-radius: 10px;
+      border: 1px solid rgba(148, 163, 184, 0.3);
+      padding: 10px 14px;
+      background: rgba(15, 23, 42, 0.8);
+      color: inherit;
+      transition: border 0.2s, box-shadow 0.2s;
+    }
+
+    input:focus, button:focus {
+      outline: none;
+      border-color: #38bdf8;
+      box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+    }
+
+    button {
+      cursor: pointer;
+      background: linear-gradient(135deg, #22d3ee, #6366f1);
+      border: none;
+      color: #0f172a;
+      font-weight: 600;
+    }
+
+    button.secondary {
+      background: rgba(148, 163, 184, 0.2);
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      color: inherit;
+    }
+
+    .grid {
+      display: grid;
+      gap: 16px;
+    }
+
+    .grid.two {
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .extremes {
+      display: flex;
+      gap: 16px;
+      align-items: center;
+      justify-content: space-between;
+      font-size: clamp(1.15rem, 3vw, 1.6rem);
+    }
+
+    .extreme-label {
+      flex: 1;
+      text-align: center;
+      padding: 14px;
+      border-radius: 12px;
+      background: rgba(15, 23, 42, 0.6);
+      border: 1px solid rgba(148, 163, 184, 0.15);
+    }
+
+    .gauge {
+      height: 12px;
+      background: rgba(148, 163, 184, 0.15);
+      border-radius: 999px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .gauge-fill {
+      position: absolute;
+      top: 0;
+      height: 100%;
+      background: linear-gradient(90deg, #f97316, #facc15);
+      transition: width 0.4s ease;
+    }
+
+    .metrics {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+
+    .metric {
+      background: rgba(15, 23, 42, 0.65);
+      border-radius: 12px;
+      padding: 16px;
+      border: 1px solid rgba(148, 163, 184, 0.2);
+    }
+
+    .metric span {
+      display: block;
+      font-size: 0.85rem;
+      color: #94a3b8;
+    }
+
+    .metric strong {
+      display: block;
+      font-size: 1.6rem;
+      color: #f8fafc;
+      margin-top: 6px;
+    }
+
+    .secret {
+      position: relative;
+      padding: 12px 16px;
+      border-radius: 12px;
+      background: rgba(15, 23, 42, 0.65);
+      border: 1px dashed rgba(248, 250, 252, 0.4);
+    }
+
+    .secret h3 {
+      margin: 0 0 8px 0;
+      font-size: 1rem;
+      color: #facc15;
+    }
+
+    .secret-value {
+      font-size: 2rem;
+      letter-spacing: 0.12em;
+      color: #fef3c7;
+    }
+
+    .secret-mask {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(15, 23, 42, 0.92);
+      border-radius: 12px;
+      border: 1px dashed rgba(248, 250, 252, 0.3);
+      transition: opacity 0.3s ease;
+    }
+
+    .secret-mask.hidden {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .hidden-text {
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(248, 250, 252, 0.7);
+    }
+
+    .log {
+      max-height: 220px;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 0.9rem;
+    }
+
+    .log-entry {
+      padding: 8px 12px;
+      border-radius: 10px;
+      background: rgba(15, 23, 42, 0.55);
+      border: 1px solid rgba(148, 163, 184, 0.12);
+    }
+
+    .diff {
+      font-size: 2.8rem;
+      font-weight: 600;
+      text-align: center;
+      color: #34d399;
+    }
+
+    .reveal-area {
+      text-align: center;
+      display: grid;
+      gap: 16px;
+    }
+
+    .hidden {
+      display: none;
+    }
+
+    @media (max-width: 720px) {
+      main {
+        padding: 20px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Wavelength · Édition Twitch</h1>
+
+    <section>
+      <header>
+        <h2>Connexion au chat Twitch</h2>
+      </header>
+      <div class="grid two">
+        <label>
+          Chaîne Twitch (sans le #)
+          <input id="channel" type="text" placeholder="nomdechaine" autocomplete="off" />
+        </label>
+        <label>
+          Pseudo Twitch du bot
+          <input id="username" type="text" placeholder="monbot" autocomplete="off" />
+        </label>
+        <label>
+          Jeton OAuth (<a href="https://twitchapps.com/tmi/" target="_blank" rel="noreferrer">obtenir un token</a>)
+          <input id="token" type="password" placeholder="oauth:xxxxxxxxxxxx" autocomplete="off" />
+        </label>
+      </div>
+      <div style="display:flex; gap:12px; flex-wrap:wrap;">
+        <button id="connectBtn">Connexion</button>
+        <button id="disconnectBtn" class="secondary">Déconnexion</button>
+      </div>
+      <div id="connectionStatus">Non connecté</div>
+    </section>
+
+    <section>
+      <header>
+        <h2>Préparation de la manche</h2>
+      </header>
+      <div class="grid two">
+        <label>
+          Extrême gauche (0)
+          <input id="leftExtreme" type="text" placeholder="Glace" />
+        </label>
+        <label>
+          Extrême droite (100)
+          <input id="rightExtreme" type="text" placeholder="Feu" />
+        </label>
+      </div>
+      <div class="secret">
+        <h3>Valeur cible du tour</h3>
+        <div class="secret-value" id="targetValue">--</div>
+        <div class="secret-mask" id="secretMask">
+          <span class="hidden-text">Caché pour le stream</span>
+        </div>
+      </div>
+      <div style="display:flex; gap:12px; flex-wrap:wrap;">
+        <button id="generateBtn">Générer une valeur</button>
+        <button id="toggleMaskBtn" class="secondary">Afficher / Masquer</button>
+        <button id="resetRoundBtn" class="secondary">Réinitialiser les votes</button>
+      </div>
+    </section>
+
+    <section>
+      <header>
+        <h2>Votes du chat</h2>
+      </header>
+      <div class="extremes">
+        <div class="extreme-label" id="extremeLeftLabel">Extrême gauche</div>
+        <div style="min-width:120px; text-align:center;">
+          <div class="gauge">
+            <div class="gauge-fill" id="gaugeFill" style="width:0%"></div>
+          </div>
+          <div style="margin-top:10px; font-size:1.4rem;" id="averageValue">--</div>
+        </div>
+        <div class="extreme-label" id="extremeRightLabel">Extrême droite</div>
+      </div>
+      <div class="metrics">
+        <div class="metric">
+          <span>Nombre de votants uniques</span>
+          <strong id="voterCount">0</strong>
+        </div>
+        <div class="metric">
+          <span>Moyenne en direct</span>
+          <strong id="liveAverage">--</strong>
+        </div>
+        <div class="metric">
+          <span>Dernier vote</span>
+          <strong id="lastVote">--</strong>
+        </div>
+      </div>
+      <div class="log" id="voteLog"></div>
+    </section>
+
+    <section>
+      <header>
+        <h2>Révélation</h2>
+      </header>
+      <div class="reveal-area">
+        <button id="revealBtn">Révéler la cible &amp; l'écart</button>
+        <div class="hidden" id="revealPanel">
+          <div>Valeur moyenne du chat : <strong id="finalAverage">--</strong></div>
+          <div>Valeur cible : <strong id="finalTarget">--</strong></div>
+          <div class="diff">Écart : <span id="difference">--</span></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script src="https://unpkg.com/tmi.js@1.8.5/dist/tmi.min.js"></script>
+  <script>
+    const state = {
+      client: null,
+      connected: false,
+      guesses: new Map(),
+      target: null
+    };
+
+    const selectors = {
+      channel: document.getElementById('channel'),
+      username: document.getElementById('username'),
+      token: document.getElementById('token'),
+      connectBtn: document.getElementById('connectBtn'),
+      disconnectBtn: document.getElementById('disconnectBtn'),
+      status: document.getElementById('connectionStatus'),
+      leftExtreme: document.getElementById('leftExtreme'),
+      rightExtreme: document.getElementById('rightExtreme'),
+      extremeLeftLabel: document.getElementById('extremeLeftLabel'),
+      extremeRightLabel: document.getElementById('extremeRightLabel'),
+      generateBtn: document.getElementById('generateBtn'),
+      toggleMaskBtn: document.getElementById('toggleMaskBtn'),
+      resetRoundBtn: document.getElementById('resetRoundBtn'),
+      targetValue: document.getElementById('targetValue'),
+      secretMask: document.getElementById('secretMask'),
+      gaugeFill: document.getElementById('gaugeFill'),
+      averageValue: document.getElementById('averageValue'),
+      voterCount: document.getElementById('voterCount'),
+      liveAverage: document.getElementById('liveAverage'),
+      lastVote: document.getElementById('lastVote'),
+      voteLog: document.getElementById('voteLog'),
+      revealBtn: document.getElementById('revealBtn'),
+      revealPanel: document.getElementById('revealPanel'),
+      finalAverage: document.getElementById('finalAverage'),
+      finalTarget: document.getElementById('finalTarget'),
+      difference: document.getElementById('difference')
+    };
+
+    function updateStatus(text, good = false) {
+      selectors.status.textContent = text;
+      selectors.status.style.color = good ? '#34d399' : '#f87171';
+    }
+
+    function connect() {
+      const channel = selectors.channel.value.trim();
+      const username = selectors.username.value.trim();
+      const token = selectors.token.value.trim();
+
+      if (!channel || !username || !token) {
+        updateStatus('Merci de remplir tous les champs avant de vous connecter.');
+        return;
+      }
+
+      if (state.client) {
+        state.client.disconnect();
+      }
+
+      state.client = new tmi.Client({
+        options: { debug: false },
+        identity: { username, password: token },
+        channels: [channel]
+      });
+
+      state.client.on('connected', () => {
+        state.connected = true;
+        updateStatus(`Connecté au chat de #${channel}`, true);
+      });
+
+      state.client.on('disconnected', () => {
+        state.connected = false;
+        updateStatus('Déconnecté');
+      });
+
+      state.client.on('message', (_channel, tags, message, self) => {
+        if (self) return;
+        const guess = parseGuess(message);
+        if (guess === null) return;
+        registerGuess(tags['display-name'] || tags.username, guess);
+      });
+
+      state.client.connect().catch((err) => {
+        console.error(err);
+        updateStatus('Échec de connexion : ' + err.message);
+      });
+    }
+
+    function disconnect() {
+      if (state.client) {
+        state.client.disconnect();
+      }
+      state.client = null;
+      state.connected = false;
+      updateStatus('Déconnecté');
+    }
+
+    function parseGuess(message) {
+      const trimmed = message.trim();
+      if (!trimmed.startsWith('!')) return null;
+      const value = trimmed.slice(1).replace(',', '.');
+      const number = Number(value);
+      if (!Number.isFinite(number)) return null;
+      const rounded = Math.round(number);
+      if (rounded < 0 || rounded > 100) return null;
+      return rounded;
+    }
+
+    function registerGuess(user, value) {
+      state.guesses.set(user.toLowerCase(), { user, value, time: new Date() });
+      selectors.lastVote.textContent = `${user} → ${value}`;
+      refreshMetrics();
+      addLogEntry(`${user} : ${value}`);
+    }
+
+    function refreshMetrics() {
+      const entries = Array.from(state.guesses.values());
+      selectors.voterCount.textContent = entries.length.toString();
+      if (!entries.length) {
+        selectors.liveAverage.textContent = '--';
+        selectors.averageValue.textContent = '--';
+        selectors.gaugeFill.style.width = '0%';
+        return;
+      }
+      const average = entries.reduce((acc, item) => acc + item.value, 0) / entries.length;
+      const formatted = average.toFixed(1);
+      selectors.liveAverage.textContent = formatted;
+      selectors.averageValue.textContent = formatted;
+      selectors.gaugeFill.style.width = `${Math.min(Math.max(average, 0), 100)}%`;
+    }
+
+    function addLogEntry(text) {
+      const entry = document.createElement('div');
+      entry.className = 'log-entry';
+      entry.textContent = text;
+      selectors.voteLog.prepend(entry);
+      while (selectors.voteLog.children.length > 50) {
+        selectors.voteLog.removeChild(selectors.voteLog.lastChild);
+      }
+    }
+
+    function generateTarget() {
+      state.target = Math.floor(Math.random() * 101);
+      selectors.targetValue.textContent = state.target.toString().padStart(2, '0');
+      selectors.secretMask.classList.remove('hidden');
+      selectors.revealPanel.classList.add('hidden');
+      selectors.finalAverage.textContent = '--';
+      selectors.finalTarget.textContent = '--';
+      selectors.difference.textContent = '--';
+    }
+
+    function toggleMask() {
+      selectors.secretMask.classList.toggle('hidden');
+    }
+
+    function resetRound() {
+      state.guesses.clear();
+      selectors.voteLog.innerHTML = '';
+      selectors.lastVote.textContent = '--';
+      selectors.voterCount.textContent = '0';
+      selectors.gaugeFill.style.width = '0%';
+      selectors.averageValue.textContent = '--';
+      selectors.liveAverage.textContent = '--';
+      selectors.revealPanel.classList.add('hidden');
+    }
+
+    function reveal() {
+      if (state.target === null) {
+        alert('Générez une valeur cible avant de révéler.');
+        return;
+      }
+      const entries = Array.from(state.guesses.values());
+      if (!entries.length) {
+        alert('Aucune participation du chat pour ce tour.');
+        return;
+      }
+      const average = entries.reduce((acc, item) => acc + item.value, 0) / entries.length;
+      const diff = Math.abs(average - state.target);
+      selectors.finalAverage.textContent = average.toFixed(1);
+      selectors.finalTarget.textContent = state.target.toString();
+      selectors.difference.textContent = diff.toFixed(1);
+      selectors.revealPanel.classList.remove('hidden');
+    }
+
+    function syncExtremes() {
+      selectors.extremeLeftLabel.textContent = selectors.leftExtreme.value || 'Extrême gauche';
+      selectors.extremeRightLabel.textContent = selectors.rightExtreme.value || 'Extrême droite';
+    }
+
+    selectors.connectBtn.addEventListener('click', connect);
+    selectors.disconnectBtn.addEventListener('click', disconnect);
+    selectors.generateBtn.addEventListener('click', generateTarget);
+    selectors.toggleMaskBtn.addEventListener('click', toggleMask);
+    selectors.resetRoundBtn.addEventListener('click', resetRound);
+    selectors.revealBtn.addEventListener('click', reveal);
+    selectors.leftExtreme.addEventListener('input', syncExtremes);
+    selectors.rightExtreme.addEventListener('input', syncExtremes);
+
+    updateStatus('Non connecté');
+    syncExtremes();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -75,6 +75,13 @@
       font-size: 0.95rem;
     }
 
+    .helper {
+      margin: 0;
+      font-size: 0.9rem;
+      color: #cbd5f5;
+      line-height: 1.4;
+    }
+
     input, button, select {
       font: inherit;
       border-radius: 10px;
@@ -267,18 +274,23 @@
       </header>
       <div class="grid two">
         <label>
-          Chaîne Twitch (sans le #)
+          Chaîne Twitch (requis, sans le #)
           <input id="channel" type="text" placeholder="nomdechaine" autocomplete="off" />
         </label>
         <label>
-          Pseudo Twitch du bot
+          Pseudo Twitch du bot (optionnel)
           <input id="username" type="text" placeholder="monbot" autocomplete="off" />
         </label>
         <label>
-          Jeton OAuth (<a href="https://twitchapps.com/tmi/" target="_blank" rel="noreferrer">obtenir un token</a>)
+          Jeton OAuth (optionnel — voir le README pour le générer)
           <input id="token" type="password" placeholder="oauth:xxxxxxxxxxxx" autocomplete="off" />
         </label>
       </div>
+      <p class="helper">
+        Pour une lecture seule du chat, seul le nom de la chaîne est requis. Laissez les champs bot et token vides
+        pour une connexion anonyme fournie par Twitch. Ajoutez un pseudo + un token uniquement si vous avez besoin
+        qu'un bot envoie des messages dans le chat.
+      </p>
       <div style="display:flex; gap:12px; flex-wrap:wrap;">
         <button id="connectBtn">Connexion</button>
         <button id="disconnectBtn" class="secondary">Déconnexion</button>
@@ -398,9 +410,14 @@
       difference: document.getElementById('difference')
     };
 
-    function updateStatus(text, good = false) {
+    function updateStatus(text, variant = 'neutral') {
       selectors.status.textContent = text;
-      selectors.status.style.color = good ? '#34d399' : '#f87171';
+      const colors = {
+        neutral: '#e5e7eb',
+        success: '#34d399',
+        error: '#f87171'
+      };
+      selectors.status.style.color = colors[variant] || colors.neutral;
     }
 
     function connect() {
@@ -408,8 +425,19 @@
       const username = selectors.username.value.trim();
       const token = selectors.token.value.trim();
 
-      if (!channel || !username || !token) {
-        updateStatus('Merci de remplir tous les champs avant de vous connecter.');
+      if (!channel) {
+        updateStatus('Merci d’indiquer le nom de la chaîne Twitch.', 'error');
+        return;
+      }
+
+      const hasUsername = username.length > 0;
+      const hasToken = token.length > 0;
+
+      if (hasUsername !== hasToken) {
+        updateStatus(
+          'Pour une connexion authentifiée, remplissez à la fois le pseudo bot et le jeton OAuth, ou laissez les deux champs vides.',
+          'error'
+        );
         return;
       }
 
@@ -417,15 +445,23 @@
         state.client.disconnect();
       }
 
-      state.client = new tmi.Client({
+      const clientOptions = {
         options: { debug: false },
-        identity: { username, password: token },
+        connection: { secure: true, reconnect: true },
         channels: [channel]
-      });
+      };
+
+      if (hasUsername && hasToken) {
+        clientOptions.identity = { username, password: token };
+      }
+
+      updateStatus('Connexion en cours…');
+
+      state.client = new tmi.Client(clientOptions);
 
       state.client.on('connected', () => {
         state.connected = true;
-        updateStatus(`Connecté au chat de #${channel}`, true);
+        updateStatus(`Connecté au chat de #${channel}`, 'success');
       });
 
       state.client.on('disconnected', () => {
@@ -442,7 +478,7 @@
 
       state.client.connect().catch((err) => {
         console.error(err);
-        updateStatus('Échec de connexion : ' + err.message);
+        updateStatus('Échec de connexion : ' + err.message, 'error');
       });
     }
 


### PR DESCRIPTION
## Summary
- add a single-page web app to host a Wavelength-inspired Twitch mini-game
- connect to Twitch chat with tmi.js to capture !number guesses and compute the live average
- provide streamer controls for generating the secret value, hiding/revealing it and resetting rounds
- document setup and usage instructions in the README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4c1020fd08332a7ea0830b2acf36f